### PR TITLE
Add missing commas; refactor pickers.js options into a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,39 +162,53 @@ The scripts below will be included when you use the "require pickers" (for versi
 Version 4.0.0+:
 
 ```javascript
-    $(document).on('ready, page:change', function() {
-      $('.timepicker').datetimepicker();
+var default_picker_options = {
+  icons: {
+    date: 'fa fa-calendar',
+    time: 'fa fa-clock-o',
+    up: 'fa fa-chevron-up',
+    down: 'fa fa-chevron-down',
+    previous: 'fa fa-chevron-left',
+    next: 'fa fa-chevron-right',
+    today: 'fa fa-crosshairs',
+    clear: 'fa fa-trash-o'
+  }
+}
 
-      $('.datetimepicker').datetimepicker();
+$(document).on('ready, page:change', function() {
+  $('.datetimepicker').datetimepicker({default_picker_options});
 
-      $('.datepicker').datetimepicker();
+  $('.timepicker').datetimepicker(default_picker_options);
 
-      $('.datetimerange').each(function(){
-        var $this = $(this)
-        var range1 = $($this.find('.input-group')[0])
-        var range2 = $($this.find('.input-group')[1])
+  $('.datepicker').datetimepicker(default_picker_options);
 
-        if(range1.data("DateTimePicker").date() != null)
-          range2.data("DateTimePicker").minDate(range1.data("DateTimePicker").date());
+  $('.datetimerange').each(function(){
+    var $this = $(this)
+    var range1 = $($this.find('.input-group')[0])
+    var range2 = $($this.find('.input-group')[1])
 
-        if(range2.data("DateTimePicker").date() != null)
-          range1.data("DateTimePicker").maxDate(range2.data("DateTimePicker").date());
+    if(range1.data("DateTimePicker").date() != null)
+      range2.data("DateTimePicker").minDate(range1.data("DateTimePicker").date());
 
-        range1.on("dp.change",function (e) {
-          if(e.date)
-            range2.data("DateTimePicker").minDate(e.date);
-          else
-            range2.data("DateTimePicker").minDate(false);
-        });
+    if(range2.data("DateTimePicker").date() != null)
+      range1.data("DateTimePicker").maxDate(range2.data("DateTimePicker").date());
 
-        range2.on("dp.change",function (e) {
-          if(e.date)
-            range1.data("DateTimePicker").maxDate(e.date);
-          else
-            range1.data("DateTimePicker").maxDate(false);
-        });
-      })
+    range1.on("dp.change",function (e) {
+      if(e.date)
+        range2.data("DateTimePicker").minDate(e.date);
+      else
+        range2.data("DateTimePicker").minDate(false);
     });
+
+    range2.on("dp.change",function (e) {
+      if(e.date)
+        range1.data("DateTimePicker").maxDate(e.date);
+      else
+        range1.data("DateTimePicker").maxDate(false);
+    });
+  })
+});
+
 ```
 
 The default values of the options:

--- a/lib/generators/datetimepicker_rails/install_generator.rb
+++ b/lib/generators/datetimepicker_rails/install_generator.rb
@@ -66,21 +66,17 @@ module DatetimepickerRails
         icons = icon_family == 'Glyphicon' ? '' : get_icons
 
         vendor 'assets/javascripts/pickers.js' do <<-FILE
+
+var default_picker_options = {
+#{icons}
+}
+
 $(document).on('ready, page:change', function() {
-  $('.datetimepicker').datetimepicker({
-//  Any customisation of object creation should be inserted here
-#{icons}
-  });
+  $('.datetimepicker').datetimepicker({default_picker_options});
 
-  $('.timepicker').datetimepicker({
-//  Any customisation of object creation should be inserted here
-#{icons}
-  });
+  $('.timepicker').datetimepicker(default_picker_options);
 
-  $('.datepicker').datetimepicker({
-//  Any customisation of object creation should be inserted here
-#{icons}
-  });
+  $('.datepicker').datetimepicker(default_picker_options);
 
   $('.datetimerange').each(function(){
     var $this = $(this)
@@ -159,16 +155,16 @@ dataOptions = {};
     private
 
       def get_icons
-        icons = "       icons: {\n"
-        icons += "          date: \'#{options[:custom_icons][:date]}\',\n"
-        icons += "          time: \'#{options[:custom_icons][:time]}\',\n"
-        icons += "          up: \'#{options[:custom_icons][:up]}\',\n"
-        icons += "          down: \'#{options[:custom_icons][:down]}\'\n"
-        icons += "          previous: \'#{options[:custom_icons][:previous]}\'\n"
-        icons += "          next: \'#{options[:custom_icons][:next]}\'\n"
-        icons += "          today: \'#{options[:custom_icons][:today]}\'\n"
-        icons += "          clear: \'#{options[:custom_icons][:clear]}\'\n"
-        icons += "      },\n"
+        icons = "    icons: {\n"
+        icons += "      date: \'#{options[:custom_icons][:date]}\',\n"
+        icons += "      time: \'#{options[:custom_icons][:time]}\',\n"
+        icons += "      up: \'#{options[:custom_icons][:up]}\',\n"
+        icons += "      down: \'#{options[:custom_icons][:down]}\',\n"
+        icons += "      previous: \'#{options[:custom_icons][:previous]}\',\n"
+        icons += "      next: \'#{options[:custom_icons][:next]}\',\n"
+        icons += "      today: \'#{options[:custom_icons][:today]}\',\n"
+        icons += "      clear: \'#{options[:custom_icons][:clear]}\'\n"
+        icons += "    },\n"
       end
 
     end


### PR DESCRIPTION
Hi,

A bug fix and an improvement:

* Add missing commas to the icons in the get_icons method. 
* Refactor the pickers.js template so that the options are stored in a variable, and used in each picker call.