### PR TITLE
Use https for the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bootstrap-datetimepicker"]
 	path = bootstrap-datetimepicker
-	url = git://github.com/eonasdan/bootstrap-datetimepicker.git
+	url = https://github.com/eonasdan/bootstrap-datetimepicker.git


### PR DESCRIPTION
Hi,

This PR changes the submodule to be cloned over HTTPS rather than the git protocol. For a read-only case such as this, there doesn't appear to be a disadvantage, while offering a slight security benefit.

I hope you find this PR helpful!